### PR TITLE
[JL] Fix hot phase serialization

### DIFF
--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/hot_phase.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/hot_phase.tsx
@@ -52,7 +52,7 @@ export const HotPhase: FunctionComponent = () => {
     watch: isUsingDefaultRolloverPath,
   });
   const { isUsingRollover } = useConfigurationIssues();
-  const isUsingDefaultRollover = get(formData, isUsingDefaultRolloverPath);
+  const isUsingDefaultRollover: boolean = get(formData, isUsingDefaultRolloverPath);
   const [showEmptyRolloverFieldsError, setShowEmptyRolloverFieldsError] = useState(false);
 
   return (
@@ -145,145 +145,145 @@ export const HotPhase: FunctionComponent = () => {
           }
           fullWidth
         >
-          <div
-            aria-live="polite"
-            role="region"
-            style={{ display: isUsingDefaultRollover === false ? undefined : 'none' }}
-          >
-            <UseField<boolean> path="_meta.hot.useRollover">
-              {(field) => (
-                <>
-                  <EuiSwitch
-                    label={field.label}
-                    checked={field.value}
-                    onChange={(e) => field.setValue(e.target.checked)}
-                    data-test-subj="rolloverSwitch"
-                  />
-                  &nbsp;
-                  <EuiIconTip
-                    type="questionInCircle"
-                    content={
-                      <FormattedMessage
-                        id="xpack.indexLifecycleMgmt.editPolicy.hotPhase.enableRolloverTipContent"
-                        defaultMessage="Roll over to a new index when the 
-    current index meets one of the defined conditions."
-                      />
-                    }
-                  />
-                </>
-              )}
-            </UseField>
-            {isUsingRollover && (
-              <>
-                <EuiSpacer size="m" />
-                {showEmptyRolloverFieldsError && (
+          {isUsingDefaultRollover === false ? (
+            <div aria-live="polite" role="region">
+              <UseField<boolean> path="_meta.hot.customRollover.enabled">
+                {(field) => (
                   <>
-                    <EuiCallOut
-                      title={i18nTexts.editPolicy.errors.rollOverConfigurationCallout.title}
-                      data-test-subj="rolloverSettingsRequired"
-                      color="danger"
-                    >
-                      <div>{i18nTexts.editPolicy.errors.rollOverConfigurationCallout.body}</div>
-                    </EuiCallOut>
-                    <EuiSpacer size="s" />
+                    <EuiSwitch
+                      label={field.label}
+                      checked={field.value}
+                      onChange={(e) => field.setValue(e.target.checked)}
+                      data-test-subj="rolloverSwitch"
+                    />
+                    &nbsp;
+                    <EuiIconTip
+                      type="questionInCircle"
+                      content={
+                        <FormattedMessage
+                          id="xpack.indexLifecycleMgmt.editPolicy.hotPhase.enableRolloverTipContent"
+                          defaultMessage="Roll over to a new index when the
+    current index meets one of the defined conditions."
+                        />
+                      }
+                    />
                   </>
                 )}
-                <EuiFlexGroup>
-                  <EuiFlexItem style={{ maxWidth: 188 }}>
-                    <UseField path={ROLLOVER_FORM_PATHS.maxSize}>
-                      {(field) => {
-                        const showErrorCallout = field.errors.some(
-                          (e) => e.code === ROLLOVER_EMPTY_VALIDATION
-                        );
-                        if (showErrorCallout !== showEmptyRolloverFieldsError) {
-                          setShowEmptyRolloverFieldsError(showErrorCallout);
-                        }
-                        return (
-                          <NumericField
-                            field={field}
-                            euiFieldProps={{
-                              'data-test-subj': `${hotProperty}-selectedMaxSizeStored`,
-                              min: 1,
-                            }}
-                          />
-                        );
-                      }}
-                    </UseField>
-                  </EuiFlexItem>
-                  <EuiFlexItem style={{ maxWidth: 188 }}>
-                    <UseField
-                      key="_meta.hot.maxStorageSizeUnit"
-                      path="_meta.hot.maxStorageSizeUnit"
-                      component={SelectField}
-                      componentProps={{
-                        'data-test-subj': `${hotProperty}-selectedMaxSizeStoredUnits`,
-                        hasEmptyLabelSpace: true,
-                        euiFieldProps: {
-                          options: maxSizeStoredUnits,
-                          'aria-label': i18n.translate(
-                            'xpack.indexLifecycleMgmt.hotPhase.maximumIndexSizeUnitsAriaLabel',
-                            {
-                              defaultMessage: 'Maximum index size units',
-                            }
-                          ),
-                        },
-                      }}
-                    />
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-                <EuiSpacer />
-                <EuiFlexGroup>
-                  <EuiFlexItem style={{ maxWidth: 188 }}>
-                    <UseField
-                      path={ROLLOVER_FORM_PATHS.maxDocs}
-                      component={NumericField}
-                      componentProps={{
-                        euiFieldProps: {
-                          'data-test-subj': `${hotProperty}-selectedMaxDocuments`,
-                          min: 1,
-                        },
-                      }}
-                    />
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-                <EuiSpacer />
-                <EuiFlexGroup>
-                  <EuiFlexItem style={{ maxWidth: 188 }}>
-                    <UseField
-                      path={ROLLOVER_FORM_PATHS.maxAge}
-                      component={NumericField}
-                      componentProps={{
-                        euiFieldProps: {
-                          'data-test-subj': `${hotProperty}-selectedMaxAge`,
-                          min: 1,
-                        },
-                      }}
-                    />
-                  </EuiFlexItem>
-                  <EuiFlexItem style={{ maxWidth: 188 }}>
-                    <UseField
-                      key="_meta.hot.maxAgeUnit"
-                      path="_meta.hot.maxAgeUnit"
-                      component={SelectField}
-                      componentProps={{
-                        'data-test-subj': `${hotProperty}-selectedMaxAgeUnits`,
-                        hasEmptyLabelSpace: true,
-                        euiFieldProps: {
-                          'aria-label': i18n.translate(
-                            'xpack.indexLifecycleMgmt.hotPhase.maximumAgeUnitsAriaLabel',
-                            {
-                              defaultMessage: 'Maximum age units',
-                            }
-                          ),
-                          options: maxAgeUnits,
-                        },
-                      }}
-                    />
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </>
-            )}
-          </div>
+              </UseField>
+              {isUsingRollover && (
+                <>
+                  <EuiSpacer size="m" />
+                  {showEmptyRolloverFieldsError && (
+                    <>
+                      <EuiCallOut
+                        title={i18nTexts.editPolicy.errors.rollOverConfigurationCallout.title}
+                        data-test-subj="rolloverSettingsRequired"
+                        color="danger"
+                      >
+                        <div>{i18nTexts.editPolicy.errors.rollOverConfigurationCallout.body}</div>
+                      </EuiCallOut>
+                      <EuiSpacer size="s" />
+                    </>
+                  )}
+                  <EuiFlexGroup>
+                    <EuiFlexItem style={{ maxWidth: 188 }}>
+                      <UseField path={ROLLOVER_FORM_PATHS.maxSize}>
+                        {(field) => {
+                          const showErrorCallout = field.errors.some(
+                            (e) => e.code === ROLLOVER_EMPTY_VALIDATION
+                          );
+                          if (showErrorCallout !== showEmptyRolloverFieldsError) {
+                            setShowEmptyRolloverFieldsError(showErrorCallout);
+                          }
+                          return (
+                            <NumericField
+                              field={field}
+                              euiFieldProps={{
+                                'data-test-subj': `${hotProperty}-selectedMaxSizeStored`,
+                                min: 1,
+                              }}
+                            />
+                          );
+                        }}
+                      </UseField>
+                    </EuiFlexItem>
+                    <EuiFlexItem style={{ maxWidth: 188 }}>
+                      <UseField
+                        key="_meta.hot.customRollover.maxStorageSizeUnit"
+                        path="_meta.hot.customRollover.maxStorageSizeUnit"
+                        component={SelectField}
+                        componentProps={{
+                          'data-test-subj': `${hotProperty}-selectedMaxSizeStoredUnits`,
+                          hasEmptyLabelSpace: true,
+                          euiFieldProps: {
+                            options: maxSizeStoredUnits,
+                            'aria-label': i18n.translate(
+                              'xpack.indexLifecycleMgmt.hotPhase.maximumIndexSizeUnitsAriaLabel',
+                              {
+                                defaultMessage: 'Maximum index size units',
+                              }
+                            ),
+                          },
+                        }}
+                      />
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                  <EuiSpacer />
+                  <EuiFlexGroup>
+                    <EuiFlexItem style={{ maxWidth: 188 }}>
+                      <UseField
+                        path={ROLLOVER_FORM_PATHS.maxDocs}
+                        component={NumericField}
+                        componentProps={{
+                          euiFieldProps: {
+                            'data-test-subj': `${hotProperty}-selectedMaxDocuments`,
+                            min: 1,
+                          },
+                        }}
+                      />
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                  <EuiSpacer />
+                  <EuiFlexGroup>
+                    <EuiFlexItem style={{ maxWidth: 188 }}>
+                      <UseField
+                        path={ROLLOVER_FORM_PATHS.maxAge}
+                        component={NumericField}
+                        componentProps={{
+                          euiFieldProps: {
+                            'data-test-subj': `${hotProperty}-selectedMaxAge`,
+                            min: 1,
+                          },
+                        }}
+                      />
+                    </EuiFlexItem>
+                    <EuiFlexItem style={{ maxWidth: 188 }}>
+                      <UseField
+                        key="_meta.hot.customRollover.maxAgeUnit"
+                        path="_meta.hot.customRollover.maxAgeUnit"
+                        component={SelectField}
+                        componentProps={{
+                          'data-test-subj': `${hotProperty}-selectedMaxAgeUnits`,
+                          hasEmptyLabelSpace: true,
+                          euiFieldProps: {
+                            'aria-label': i18n.translate(
+                              'xpack.indexLifecycleMgmt.hotPhase.maximumAgeUnitsAriaLabel',
+                              {
+                                defaultMessage: 'Maximum age units',
+                              }
+                            ),
+                            options: maxAgeUnits,
+                          },
+                        }}
+                      />
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </>
+              )}
+            </div>
+          ) : (
+            <div />
+          )}
         </DescribedFormRow>
         {isUsingRollover && (
           <>

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/constants.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/constants.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export const useRolloverPath = '_meta.hot.useRollover';
+export const isUsingCustomRolloverPath = '_meta.hot.customRollover.enabled';
 
 export const isUsingDefaultRolloverPath = '_meta.hot.isUsingDefaultRollover';
 

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/form/configuration_issues_context.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/form/configuration_issues_context.tsx
@@ -9,7 +9,7 @@ import React, { FunctionComponent, createContext, useContext } from 'react';
 
 import { useFormData } from '../../../../shared_imports';
 
-import { isUsingDefaultRolloverPath, useRolloverPath } from '../constants';
+import { isUsingDefaultRolloverPath, isUsingCustomRolloverPath } from '../constants';
 
 export interface ConfigurationIssues {
   /**
@@ -33,14 +33,18 @@ const pathToHotPhaseSearchableSnapshot =
 
 export const ConfigurationIssuesProvider: FunctionComponent = ({ children }) => {
   const [formData] = useFormData({
-    watch: [pathToHotPhaseSearchableSnapshot, useRolloverPath, isUsingDefaultRolloverPath],
+    watch: [
+      pathToHotPhaseSearchableSnapshot,
+      isUsingCustomRolloverPath,
+      isUsingDefaultRolloverPath,
+    ],
   });
   const isUsingDefaultRollover = get(formData, isUsingDefaultRolloverPath);
-  const rolloverSwitchEnabled = get(formData, useRolloverPath);
+  const isUsingCustomRollover = get(formData, isUsingCustomRolloverPath);
   return (
     <ConfigurationIssuesContext.Provider
       value={{
-        isUsingRollover: isUsingDefaultRollover === false ? rolloverSwitchEnabled : true,
+        isUsingRollover: isUsingDefaultRollover === false ? isUsingCustomRollover : true,
         isUsingSearchableSnapshotInHotPhase:
           get(formData, pathToHotPhaseSearchableSnapshot) != null,
       }}

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/form/deserializer.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/form/deserializer.ts
@@ -21,8 +21,10 @@ export const deserializer = (policy: SerializedPolicy): FormInternal => {
 
   const _meta: FormInternal['_meta'] = {
     hot: {
-      useRollover: Boolean(hot?.actions?.rollover),
       isUsingDefaultRollover: isUsingDefaultRollover(policy),
+      customRollover: {
+        enabled: Boolean(hot?.actions?.rollover),
+      },
       bestCompression: hot?.actions?.forcemerge?.index_codec === 'best_compression',
       readonlyEnabled: Boolean(hot?.actions?.readonly),
     },
@@ -53,13 +55,13 @@ export const deserializer = (policy: SerializedPolicy): FormInternal => {
         if (draft.phases.hot.actions.rollover.max_size) {
           const maxSize = splitSizeAndUnits(draft.phases.hot.actions.rollover.max_size);
           draft.phases.hot.actions.rollover.max_size = maxSize.size;
-          draft._meta.hot.maxStorageSizeUnit = maxSize.units;
+          draft._meta.hot.customRollover.maxStorageSizeUnit = maxSize.units;
         }
 
         if (draft.phases.hot.actions.rollover.max_age) {
           const maxAge = splitSizeAndUnits(draft.phases.hot.actions.rollover.max_age);
           draft.phases.hot.actions.rollover.max_age = maxAge.size;
-          draft._meta.hot.maxAgeUnit = maxAge.units;
+          draft._meta.hot.customRollover.maxAgeUnit = maxAge.units;
         }
       }
 

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/form/deserializer_and_serializer.test.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/form/deserializer_and_serializer.test.ts
@@ -233,7 +233,10 @@ describe('deserializer and serializer', () => {
   });
 
   it('removes forcemerge, readonly, and rollover config when rollover is disabled in hot phase', () => {
-    formInternal._meta.hot.useRollover = false;
+    // These two toggles jointly control whether rollover is enabled since the default is
+    // for rollover to be enabled.
+    formInternal._meta.hot.isUsingDefaultRollover = false;
+    formInternal._meta.hot.customRollover.enabled = false;
 
     const result = serializer(formInternal);
 
@@ -243,7 +246,7 @@ describe('deserializer and serializer', () => {
   });
 
   it('removes min_age from warm when rollover is enabled', () => {
-    formInternal._meta.hot.useRollover = true;
+    formInternal._meta.hot.customRollover.enabled = true;
     formInternal._meta.warm.warmPhaseOnRollover = true;
 
     const result = serializer(formInternal);

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/form/schema.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/form/schema.ts
@@ -32,23 +32,25 @@ const serializers = {
 export const schema: FormSchema<FormInternal> = {
   _meta: {
     hot: {
-      useRollover: {
-        defaultValue: true,
-        label: i18n.translate('xpack.indexLifecycleMgmt.hotPhase.enableRolloverLabel', {
-          defaultMessage: 'Enable rollover',
-        }),
-      },
       isUsingDefaultRollover: {
         defaultValue: true,
         label: i18n.translate('xpack.indexLifecycleMgmt.hotPhase.isUsingDefaultRollover', {
           defaultMessage: 'Use recommended defaults',
         }),
       },
-      maxStorageSizeUnit: {
-        defaultValue: 'gb',
-      },
-      maxAgeUnit: {
-        defaultValue: 'd',
+      customRollover: {
+        enabled: {
+          defaultValue: true,
+          label: i18n.translate('xpack.indexLifecycleMgmt.hotPhase.enableRolloverLabel', {
+            defaultMessage: 'Enable rollover',
+          }),
+        },
+        maxStorageSizeUnit: {
+          defaultValue: 'gb',
+        },
+        maxAgeUnit: {
+          defaultValue: 'd',
+        },
       },
       bestCompression: {
         label: i18nTexts.editPolicy.bestCompressionFieldLabel,

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/serializer.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/serializer.ts
@@ -56,6 +56,7 @@ export const createSerializer = (originalPolicy?: SerializedPolicy) => (
         if (_meta.hot.isUsingDefaultRollover) {
           hotPhaseActions.rollover = cloneDeep(defaultRolloverAction);
         } else {
+          // We are using user-defined, custom rollover settings.
           if (updatedPolicy.phases.hot!.actions.rollover?.max_age) {
             hotPhaseActions.rollover.max_age = `${hotPhaseActions.rollover.max_age}${_meta.hot.customRollover.maxAgeUnit}`;
           } else {

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/serializer.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/serializer.ts
@@ -5,7 +5,6 @@
  */
 
 import { produce } from 'immer';
-
 import { merge, cloneDeep } from 'lodash';
 
 import { SerializedPolicy } from '../../../../../../common/types';
@@ -29,6 +28,13 @@ export const createSerializer = (originalPolicy?: SerializedPolicy) => (
     // Copy over all updated fields
     merge(draft, updatedPolicy);
 
+    /**
+     * Important shared values for serialization
+     */
+    const isUsingRollover = Boolean(
+      _meta.hot.isUsingDefaultRollover || _meta.hot.customRollover.enabled
+    );
+
     // Next copy over all meta fields and delete any fields that have been removed
     // by fields exposed in the form. It is very important that we do not delete
     // data that the form does not control! E.g., unfollow action in hot phase.
@@ -43,12 +49,15 @@ export const createSerializer = (originalPolicy?: SerializedPolicy) => (
     if (draft.phases.hot?.actions) {
       const hotPhaseActions = draft.phases.hot.actions;
 
-      if (hotPhaseActions.rollover && _meta.hot.useRollover) {
+      /**
+       * HOT PHASE ROLLOVER
+       */
+      if (hotPhaseActions.rollover && isUsingRollover) {
         if (_meta.hot.isUsingDefaultRollover) {
           hotPhaseActions.rollover = cloneDeep(defaultRolloverAction);
         } else {
           if (updatedPolicy.phases.hot!.actions.rollover?.max_age) {
-            hotPhaseActions.rollover.max_age = `${hotPhaseActions.rollover.max_age}${_meta.hot.maxAgeUnit}`;
+            hotPhaseActions.rollover.max_age = `${hotPhaseActions.rollover.max_age}${_meta.hot.customRollover.maxAgeUnit}`;
           } else {
             delete hotPhaseActions.rollover.max_age;
           }
@@ -58,12 +67,15 @@ export const createSerializer = (originalPolicy?: SerializedPolicy) => (
           }
 
           if (updatedPolicy.phases.hot!.actions.rollover?.max_size) {
-            hotPhaseActions.rollover.max_size = `${hotPhaseActions.rollover.max_size}${_meta.hot.maxStorageSizeUnit}`;
+            hotPhaseActions.rollover.max_size = `${hotPhaseActions.rollover.max_size}${_meta.hot.customRollover.maxStorageSizeUnit}`;
           } else {
             delete hotPhaseActions.rollover.max_size;
           }
         }
 
+        /**
+         * HOT PHASE FORCEMERGE
+         */
         if (!updatedPolicy.phases.hot!.actions?.forcemerge) {
           delete hotPhaseActions.forcemerge;
         } else if (_meta.hot.bestCompression) {
@@ -74,6 +86,9 @@ export const createSerializer = (originalPolicy?: SerializedPolicy) => (
           hotPhaseActions.forcemerge.index_codec = 'best_compression';
         }
 
+        /**
+         * HOT PHASE READ-ONLY
+         */
         if (_meta.hot.readonlyEnabled) {
           hotPhaseActions.readonly = hotPhaseActions.readonly ?? {};
         } else {
@@ -85,14 +100,23 @@ export const createSerializer = (originalPolicy?: SerializedPolicy) => (
         delete hotPhaseActions.readonly;
       }
 
+      /**
+       * HOT PHASE SET PRIORITY
+       */
       if (!updatedPolicy.phases.hot!.actions?.set_priority) {
         delete hotPhaseActions.set_priority;
       }
 
+      /**
+       * HOT PHASE SHRINK
+       */
       if (!updatedPolicy.phases.hot?.actions?.shrink) {
         delete hotPhaseActions.shrink;
       }
 
+      /**
+       * HOT PHASE SEARCHABLE SNAPSHOT
+       */
       if (!updatedPolicy.phases.hot!.actions?.searchable_snapshot) {
         delete hotPhaseActions.searchable_snapshot;
       }
@@ -104,11 +128,16 @@ export const createSerializer = (originalPolicy?: SerializedPolicy) => (
     if (_meta.warm.enabled) {
       draft.phases.warm!.actions = draft.phases.warm?.actions ?? {};
       const warmPhase = draft.phases.warm!;
-      // If warm phase on rollover is enabled, delete min age field
-      // An index lifecycle switches to warm phase when rollover occurs, so you cannot specify a warm phase time
-      // They are mutually exclusive
+
+      /**
+       * WARM PHASE MIN AGE
+       *
+       * If warm phase on rollover is enabled, delete min age field
+       * An index lifecycle switches to warm phase when rollover occurs, so you cannot specify a warm phase time
+       * They are mutually exclusive
+       */
       if (
-        (!_meta.hot.useRollover || !_meta.warm.warmPhaseOnRollover) &&
+        (!isUsingRollover || !_meta.warm.warmPhaseOnRollover) &&
         updatedPolicy.phases.warm?.min_age
       ) {
         warmPhase.min_age = `${updatedPolicy.phases.warm!.min_age}${_meta.warm.minAgeUnit}`;
@@ -116,6 +145,9 @@ export const createSerializer = (originalPolicy?: SerializedPolicy) => (
         delete warmPhase.min_age;
       }
 
+      /**
+       * WARM PHASE DATA ALLOCATION
+       */
       warmPhase.actions = serializeMigrateAndAllocateActions(
         _meta.warm,
         warmPhase.actions,
@@ -123,22 +155,34 @@ export const createSerializer = (originalPolicy?: SerializedPolicy) => (
         updatedPolicy.phases.warm?.actions?.allocate?.number_of_replicas
       );
 
+      /**
+       * WARM PHASE FORCEMERGE
+       */
       if (!updatedPolicy.phases.warm?.actions?.forcemerge) {
         delete warmPhase.actions.forcemerge;
       } else if (_meta.warm.bestCompression) {
         warmPhase.actions.forcemerge!.index_codec = 'best_compression';
       }
 
+      /**
+       * WARM PHASE READ ONLY
+       */
       if (_meta.warm.readonlyEnabled) {
         warmPhase.actions.readonly = warmPhase.actions.readonly ?? {};
       } else {
         delete warmPhase.actions.readonly;
       }
 
+      /**
+       * WARM PHASE SET PRIORITY
+       */
       if (!updatedPolicy.phases.warm?.actions?.set_priority) {
         delete warmPhase.actions.set_priority;
       }
 
+      /**
+       * WARM PHASE SHRINK
+       */
       if (!updatedPolicy.phases.warm?.actions?.shrink) {
         delete warmPhase.actions.shrink;
       }
@@ -153,10 +197,16 @@ export const createSerializer = (originalPolicy?: SerializedPolicy) => (
       draft.phases.cold!.actions = draft.phases.cold?.actions ?? {};
       const coldPhase = draft.phases.cold!;
 
+      /**
+       * COLD PHASE MIN AGE
+       */
       if (updatedPolicy.phases.cold?.min_age) {
         coldPhase.min_age = `${updatedPolicy.phases.cold!.min_age}${_meta.cold.minAgeUnit}`;
       }
 
+      /**
+       * COLD PHASE DATA ALLOCATION
+       */
       coldPhase.actions = serializeMigrateAndAllocateActions(
         _meta.cold,
         coldPhase.actions,
@@ -164,16 +214,25 @@ export const createSerializer = (originalPolicy?: SerializedPolicy) => (
         updatedPolicy.phases.cold?.actions?.allocate?.number_of_replicas
       );
 
+      /**
+       * COLD PHASE FREEZE
+       */
       if (_meta.cold.freezeEnabled) {
         coldPhase.actions.freeze = coldPhase.actions.freeze ?? {};
       } else {
         delete coldPhase.actions.freeze;
       }
 
+      /**
+       * COLD PHASE SET PRIORITY
+       */
       if (!updatedPolicy.phases.cold?.actions?.set_priority) {
         delete coldPhase.actions.set_priority;
       }
 
+      /**
+       * COLD PHASE SEARCHABLE SNAPSHOT
+       */
       if (!updatedPolicy.phases.cold?.actions?.searchable_snapshot) {
         delete coldPhase.actions.searchable_snapshot;
       }
@@ -186,12 +245,23 @@ export const createSerializer = (originalPolicy?: SerializedPolicy) => (
      */
     if (_meta.delete.enabled) {
       const deletePhase = draft.phases.delete!;
+
+      /**
+       * DELETE PHASE DELETE
+       */
       deletePhase.actions = deletePhase.actions ?? {};
       deletePhase.actions.delete = deletePhase.actions.delete ?? {};
+
+      /**
+       * DELETE PHASE SEARCHABLE SNAPSHOT
+       */
       if (updatedPolicy.phases.delete?.min_age) {
         deletePhase.min_age = `${updatedPolicy.phases.delete!.min_age}${_meta.delete.minAgeUnit}`;
       }
 
+      /**
+       * DELETE PHASE WAIT FOR SNAPSHOT
+       */
       if (!updatedPolicy.phases.delete?.actions?.wait_for_snapshot) {
         delete deletePhase.actions.wait_for_snapshot;
       }

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/types.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/types.ts
@@ -22,11 +22,23 @@ export interface ForcemergeFields {
 }
 
 interface HotPhaseMetaFields extends ForcemergeFields {
-  useRollover: boolean;
+  /**
+   * By default rollover is enabled with set values for max age, max size and max docs. In this policy form
+   * opting in to default rollover overrides custom rollover values.
+   */
   isUsingDefaultRollover: boolean;
-  maxStorageSizeUnit?: string;
-  maxAgeUnit?: string;
+
   readonlyEnabled: boolean;
+
+  /**
+   * If a policy has defined values other than the default rollover {@link defaultRolloverAction}, we store
+   * them here.
+   */
+  customRollover: {
+    enabled: boolean;
+    maxStorageSizeUnit?: string;
+    maxAgeUnit?: string;
+  };
 }
 
 interface WarmPhaseMetaFields extends DataAllocationMetaFields, MinAgeField, ForcemergeFields {


### PR DESCRIPTION
## Summary

Great job discovering this bug @alisonelizabeth ! I noticed when I was reviewing the code that some of the types were very unhelpfully named, so I made this PR to fix that. I also noticed there was one more bug condition when:

1. default rollover is disabled
2. then "custom" rollover is disabled
3. then default rollover is re-enabled

This would result in default rollover not being added to generated policy JSON. I think most of the reason for this has to do with how the form lib works, and my bad choice in variable names and lack of comments. So I tried to remedy this by doing the following:

* Updated internal form state to more clearly indicate when rollover is being used vs not.
* Actually hide the custom rollover fields (do not render them) when default rollover is in use
* Added a lot more comments to the serialiser
* Updated tests

Let me know what you think!